### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,6 +38,7 @@
 - [bellman](https://github.com/zkcrypto/bellman/) - Rust library for zk-SNARK proofs
   - [[Groth16]](https://eprint.iacr.org/2016/260.pdf)
 - [ZKBoo](https://github.com/Sobuno/ZKBoo)
+- [ZKB++](https://github.com/IAIK/gzkbpp)
 - [[BCC+16]](https://eprint.iacr.org/2016/263.pdf)
   - [BulletProofLib](https://github.com/bbuenz/BulletProofLib) - Java implementation (implements [Bulletproofs [BBBPWM17]](https://web.stanford.edu/~buenz/pubs/bulletproofs.pdf) approach)
   - [secp256k1-zkp (experimental)](https://github.com/ElementsProject/secp256k1-zkp/pull/16) - C implementation on secp256k1 (implements [Bulletproofs [BBBPWM17]](https://web.stanford.edu/~buenz/pubs/bulletproofs.pdf) approach)


### PR DESCRIPTION
Added GitHub link to an implementation of ZKB++, which is an improved version of ZKBoo. In this implementation, both the inner circuit and the field, in which the computations take place, can easily be exchanged.