### PR TITLE
Adds ZEXE repo to index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -76,6 +76,8 @@
 - [snarkjs](https://github.com/iden3/snarkjs) - JavaScript library for zk-SNARK proofs
   - [[GGPR13]](https://eprint.iacr.org/2013/279.pdf) (implements [[BCTV14a]](http://eprint.iacr.org/2013/879) approach)
   - [[Groth16]](https://eprint.iacr.org/2016/260.pdf)
+- [ZEXE](https://github.com/scipr-lab/zexe) - a Rust library for decentralized private computation
+  - [[GM17]](https://eprint.iacr.org/2017/540.pdf)
 
 ## Generating structured reference strings
 Some proving systems require a structured reference string (SRS). The following works discuss secure SRS generation.
@@ -89,6 +91,7 @@ Some proving systems require a structured reference string (SRS). The following 
 - [jsnark](https://github.com/akosba/jsnark) - Java library for building circuits for preprocessing zk-SNARKs, backed by libsnark
 - [ZoKrates](https://github.com/JacobEberhardt/ZoKrates) - Toolbox for zk-SNARKs on Ethereum, backed by libsnark
 - [Snarky](https://github.com/o1-labs/snarky) - OCaml front-end for writing R1CS SNARKs, currently backed by libsnark
+- [ZEXE](https://github.com/scipr-lab/zexe)'s snark-gadgets - Rust module for building circuits, comes with pre-built algebra circuits
 
 ## General-purpose compilers from high-level languages
 - [ZKPDL [MEKHL10]](https://www.usenix.org/legacy/event/sec10/tech/full_papers/Meiklejohn.pdf)


### PR DESCRIPTION
ZEXE comes with a Rust-based implementation of GM17 which references the libsnark GM17 implementation. ZEXE also has a dedicated crate with circuits for bits, fields, curves, and pairings, which can be used to create new gadgets for constructing zero-knowledge proofs.
