### PR TITLE
Add r1cs crate

### DIFF
--- a/index.md
+++ b/index.md
@@ -141,6 +141,7 @@ Some proving systems require a structured reference string (SRS). The following 
 | [Circomlib] | Typed JS | JavaScript    |           | Library of basic circuits for Circom |
 | [ZEXE]'s snark-gadgets |      | Rust   | ZEXE      | Module for building circuits, comes with pre-built algebra circuits |
 | [ZkVM]      |          | Rust   | bulletproofs | Language for writing confidential smart contracts that create Bulletproofs R1CS proofs |
+| [r1cs]      |          | Rust          |           | Library for building R1CS gadgets |
 
 [sapling-crypto]: https://github.com/zcash/librustzcash/tree/master/sapling-crypto/src/circuit
 [jsnark]: https://github.com/akosba/jsnark
@@ -150,6 +151,7 @@ Some proving systems require a structured reference string (SRS). The following 
 [Circomlib]: https://github.com/iden3/circomlib
 [ZEXE]: https://github.com/scipr-lab/zexe
 [ZkVM]: https://github.com/interstellar/slingshot/tree/main/zkvm
+[r1cs]: https://crates.io/crates/r1cs
 
 ## General-purpose compilers from high-level languages
 - [ZKPDL [MEKHL10]](https://www.usenix.org/legacy/event/sec10/tech/full_papers/Meiklejohn.pdf)

--- a/index.md
+++ b/index.md
@@ -141,7 +141,7 @@ Some proving systems require a structured reference string (SRS). The following 
 | [Circomlib] | Typed JS | JavaScript    |           | Library of basic circuits for Circom |
 | [ZEXE]'s snark-gadgets |      | Rust   | ZEXE      | Module for building circuits, comes with pre-built algebra circuits |
 | [ZkVM]      |          | Rust   | bulletproofs | Language for writing confidential smart contracts that create Bulletproofs R1CS proofs |
-| [r1cs]      |          | Rust          |           | Library for building R1CS gadgets |
+| [r1cs]      |          | Rust          | bellman   | Library for building R1CS gadgets |
 
 [sapling-crypto]: https://github.com/zcash/librustzcash/tree/master/sapling-crypto/src/circuit
 [jsnark]: https://github.com/akosba/jsnark


### PR DESCRIPTION
This is a Rust library for building R1CS gadgets. It offers a lot of built-in features, like

- Basic operations on field elements, booleans and binary numbers
- Verifying permutations and sorting using AS-Waksman networks
- MiMC, Poseidon, Rescue, and common constructions such as Sponge functions
- Merkle proofs